### PR TITLE
[codex] Fix nested group drag offset

### DIFF
--- a/cypress/e2e/kozaneba/test_drag.cy.ts
+++ b/cypress/e2e/kozaneba/test_drag.cy.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import { TGroupItem } from "../../../src/Global/TGroupItem";
+import { TItemId } from "../../../src/Global/TItemId";
 import {
   KOZANE_BORDER,
   KOZANE_WIDTH,
@@ -16,6 +17,30 @@ import {
 } from "../../support/e2e";
 import { TITLE_HEIGHT } from "../../../src/dimension/BORDER";
 import { constants } from "../../../src/API/constants";
+import { TWorldCoord } from "../../../src/dimension/world_to_screen";
+
+const ready_nested_groups_with_offset_parent = () => {
+  cy.movidea((m) => {
+    m.make_one_kozane({
+      id: "leaf" as TItemId,
+      text: "leaf",
+      position: [0, 0] as TWorldCoord,
+    });
+    m.make_items_into_new_group(["leaf" as TItemId], {
+      id: "C" as TItemId,
+      text: "C",
+    });
+    m.make_items_into_new_group(["C" as TItemId], {
+      id: "B" as TItemId,
+      text: "B",
+    });
+    m.make_items_into_new_group(["B" as TItemId], {
+      id: "A" as TItemId,
+      text: "A",
+      position: [100, 80] as TWorldCoord,
+    });
+  });
+};
 
 describe("drag", () => {
   beforeEach(() => {
@@ -129,6 +154,7 @@ describe("drag", () => {
     cy.testid("1").should("hasPosition", [184, 199]);
 
     do_drag("G1", "ba", 0, 0);
+    cy.testid("G1").should("hasPosition", [0, 0]);
     do_drag("G1", "G2", 0, 0);
     cy.testid("1").should("hasPosition", [225, 225]);
 
@@ -137,6 +163,31 @@ describe("drag", () => {
     let pos = [100, 100];
     // was: pos = [59, 74];
     cy.testid("1").should("hasPosition", pos);
+  });
+
+  it("keeps position when dragging a root group into a nested group", () => {
+    ready_nested_groups_with_offset_parent();
+
+    do_drag("C", "ba", 0, 0);
+    cy.getGlobal((g) => g.drawOrder.includes("C")).should("eql", true);
+    cy.testid("B").should(($b) => {
+      const rect = $b[0]!.getBoundingClientRect();
+      expect(rect.width).to.eq(160);
+    });
+
+    let dropPosition: [number, number] = [0, 0];
+    cy.testid("B").then(($b) => {
+      const rect = $b[0]!.getBoundingClientRect();
+      dropPosition = [rect.x, rect.y];
+    });
+
+    do_drag("C", "B", 0, 0);
+    cy.testid("C").should(($c) => {
+      const rect = $c[0]!.getBoundingClientRect();
+      expect(rect.x).to.be.closeTo(dropPosition[0], 0.001);
+      expect(rect.y).to.be.closeTo(dropPosition[1], 0.001);
+    });
+    cy.getGroup("B", (g) => g.items).should("eql", ["C"]);
   });
 
   // Broken

--- a/src/Event/drag_drop_item_into_group.ts
+++ b/src/Event/drag_drop_item_into_group.ts
@@ -55,7 +55,8 @@ export function drag_drop_item_into_group(
     } else {
       g.drawOrder = remove_item_from(g.drawOrder, target_id);
       group_draft.items.push(target_id);
-      position = sub_v2w(position, group_draft.position);
+      const new_offset = get_total_offset_of_parents(group_id, g);
+      position = sub_v2w(position, new_offset);
     }
     const target = get_item(g, target_id);
     target.position = position;

--- a/src/Event/get_total_offset_of_parents.ts
+++ b/src/Event/get_total_offset_of_parents.ts
@@ -11,7 +11,7 @@ export const get_total_offset_of_parents = (parent_id: TItemId, g: State) => {
   while (current_parent) {
     const parent = get_item(g, current_parent);
     offset = add_v2w(offset, parent.position);
-    const next_parent = find_parent(current_parent);
+    const next_parent = find_parent(current_parent, g);
     if (!next_parent) {
       break;
     }


### PR DESCRIPTION
## Summary

Fixes nested group drag positioning when a group is dragged from the root into another group nested under an offset parent.

## Root Cause

The root-to-group drop path in `drag_drop_item_into_group` subtracted only the destination group's own `position`. For nested destinations, that ignored ancestor group offsets. `get_total_offset_of_parents` also accepted a draft state but used `find_parent` without passing that state, which could mix current and draft parent relationships.

## Changes

- Use the provided state when finding parents during total parent offset calculation.
- Subtract the full destination parent-chain offset when dropping a root item into a group.
- Add a regression case for dragging a root group into a nested group under an offset parent.
- Make the existing nested drag regression wait for the first drop to finish rendering before starting the next drag.

## Validation

- `npm test -- --watchAll=false`
- `npm run build`
- `env -u ELECTRON_RUN_AS_NODE npx cypress run --spec cypress/e2e/kozaneba/test_drag.cy.ts --config baseUrl=http://localhost:3022,video=false,pageLoadTimeout=120000`
- `env -u ELECTRON_RUN_AS_NODE npx firebase emulators:exec --only auth,firestore "env -u ELECTRON_RUN_AS_NODE npx cypress run --spec 'cypress/e2e/kozaneba/*.cy.ts' --config baseUrl=http://localhost:3022,video=false,pageLoadTimeout=120000"`