### PR TITLE
Add coordinate logic unit tests

### DIFF
--- a/src/Event/drag_drop_item_into_group.ts
+++ b/src/Event/drag_drop_item_into_group.ts
@@ -1,5 +1,4 @@
 import { mark_local_changed } from "../utils/mark_local_changed";
-import { add_v2w, sub_v2w } from "../dimension/V2";
 import { updateGlobal } from "../Global/updateGlobal";
 import { find_parent } from "../utils/find_parent";
 import { TGroupItem } from "../Global/TGroupItem";
@@ -16,7 +15,7 @@ import { dev_log } from "../utils/dev";
 import { Sentry } from "../initSentry";
 import { drag_drop_item } from "./drag_drop_item";
 import { getGlobal } from "reactn";
-import { get_total_offset_of_parents } from "./get_total_offset_of_parents";
+import { get_position_after_parent_change } from "./get_position_after_parent_change";
 
 export function drag_drop_item_into_group(
   group_id: TItemId,
@@ -41,11 +40,12 @@ export function drag_drop_item_into_group(
       // `p` may equals to `group`, it's OK
       p.items = remove_item_from(p.items, target_id);
       group_draft.items.push(target_id);
-      const perv_offset = get_total_offset_of_parents(previous_parent, g);
-      const new_offset = get_total_offset_of_parents(group_id, g);
-
-      position = add_v2w(position, perv_offset);
-      position = sub_v2w(position, new_offset);
+      position = get_position_after_parent_change(
+        position,
+        previous_parent,
+        group_id,
+        g
+      );
 
       if (p.items.length === 0 && p.text === "") {
         remove_item(g, previous_parent);
@@ -55,8 +55,7 @@ export function drag_drop_item_into_group(
     } else {
       g.drawOrder = remove_item_from(g.drawOrder, target_id);
       group_draft.items.push(target_id);
-      const new_offset = get_total_offset_of_parents(group_id, g);
-      position = sub_v2w(position, new_offset);
+      position = get_position_after_parent_change(position, null, group_id, g);
     }
     const target = get_item(g, target_id);
     target.position = position;

--- a/src/Event/get_position_after_parent_change.test.ts
+++ b/src/Event/get_position_after_parent_change.test.ts
@@ -1,0 +1,90 @@
+import { State } from "reactn/default";
+import { add_v2w } from "../dimension/V2";
+import { TGroupItem } from "../Global/TGroupItem";
+import { TKozaneItem } from "../Global/TKozaneItem";
+import { TItemId } from "../Global/TItemId";
+import { TWorldCoord } from "../dimension/world_to_screen";
+import { get_total_offset_of_parents } from "./get_total_offset_of_parents";
+import { get_position_after_parent_change } from "./get_position_after_parent_change";
+
+const id = (value: string) => value as TItemId;
+const world = (x: number, y: number) => [x, y] as TWorldCoord;
+
+const group = (
+  value: string,
+  position: TWorldCoord,
+  items: string[]
+): TGroupItem => ({
+  type: "group",
+  text: "",
+  position,
+  items: items.map(id),
+  id: id(value),
+  scale: 1,
+  isOpen: true,
+});
+
+const kozane = (value: string, position: TWorldCoord): TKozaneItem => ({
+  type: "kozane",
+  text: value,
+  position,
+  id: id(value),
+  scale: 1,
+});
+
+const state = (
+  drawOrder: string[],
+  itemStore: State["itemStore"]
+): State =>
+  ({
+    drawOrder: drawOrder.map(id),
+    itemStore,
+  } as State);
+
+describe("get_position_after_parent_change", () => {
+  test("subtracts the full parent chain when a root item enters a nested group", () => {
+    const draft = state(["A", "C"], {
+      A: group("A", world(100, 50), ["B"]),
+      B: group("B", world(30, 20), []),
+      C: kozane("C", world(150, 100)),
+    });
+
+    expect(
+      get_position_after_parent_change(world(150, 100), null, id("B"), draft)
+    ).toEqual(world(20, 30));
+  });
+
+  test("keeps world position stable when C moves root and back into A(B(C))", () => {
+    const nested = state(["A"], {
+      A: group("A", world(100, 50), ["B"]),
+      B: group("B", world(30, 20), ["C"]),
+      C: kozane("C", world(5, 6)),
+    });
+    const nestedC = nested.itemStore.C;
+    if (nestedC === undefined) {
+      throw new Error("missing C");
+    }
+    const rootPosition = add_v2w(
+      nestedC.position,
+      get_total_offset_of_parents(id("B"), nested)
+    );
+
+    const asRoot = state(["A", "C"], {
+      A: group("A", world(100, 50), ["B"]),
+      B: group("B", world(30, 20), []),
+      C: kozane("C", rootPosition),
+    });
+
+    const localPosition = get_position_after_parent_change(
+      rootPosition,
+      null,
+      id("B"),
+      asRoot
+    );
+
+    expect(localPosition).toEqual(world(5, 6));
+    expect(
+      add_v2w(localPosition, get_total_offset_of_parents(id("B"), asRoot))
+    ).toEqual(rootPosition);
+  });
+});

--- a/src/Event/get_position_after_parent_change.ts
+++ b/src/Event/get_position_after_parent_change.ts
@@ -1,0 +1,20 @@
+import { State } from "reactn/default";
+import { add_v2w, sub_v2w } from "../dimension/V2";
+import { TWorldCoord } from "../dimension/world_to_screen";
+import { TItemId } from "../Global/TItemId";
+import { get_total_offset_of_parents } from "./get_total_offset_of_parents";
+
+export const get_position_after_parent_change = (
+  position: TWorldCoord,
+  previous_parent: TItemId | null,
+  next_parent: TItemId,
+  g: State
+): TWorldCoord => {
+  const next_offset = get_total_offset_of_parents(next_parent, g);
+  if (previous_parent === null) {
+    return sub_v2w(position, next_offset);
+  }
+
+  const previous_offset = get_total_offset_of_parents(previous_parent, g);
+  return sub_v2w(add_v2w(position, previous_offset), next_offset);
+};

--- a/src/Event/get_total_offset_of_parents.test.ts
+++ b/src/Event/get_total_offset_of_parents.test.ts
@@ -1,0 +1,62 @@
+import { setGlobal } from "reactn";
+import { State } from "reactn/default";
+import { TGroupItem } from "../Global/TGroupItem";
+import { TKozaneItem } from "../Global/TKozaneItem";
+import { TItemId } from "../Global/TItemId";
+import { TWorldCoord } from "../dimension/world_to_screen";
+import { get_total_offset_of_parents } from "./get_total_offset_of_parents";
+
+const id = (value: string) => value as TItemId;
+const world = (x: number, y: number) => [x, y] as TWorldCoord;
+
+const group = (
+  value: string,
+  position: TWorldCoord,
+  items: string[]
+): TGroupItem => ({
+  type: "group",
+  text: "",
+  position,
+  items: items.map(id),
+  id: id(value),
+  scale: 1,
+  isOpen: true,
+});
+
+const kozane = (value: string, position: TWorldCoord): TKozaneItem => ({
+  type: "kozane",
+  text: value,
+  position,
+  id: id(value),
+  scale: 1,
+});
+
+const state = (
+  drawOrder: string[],
+  itemStore: State["itemStore"]
+): State =>
+  ({
+    drawOrder: drawOrder.map(id),
+    itemStore,
+  } as State);
+
+describe("get_total_offset_of_parents", () => {
+  test("uses the supplied state when traversing parent chain", () => {
+    setGlobal(
+      state(["B"], {
+        B: group("B", world(30, 20), ["C"]),
+        C: kozane("C", world(5, 6)),
+      })
+    );
+
+    const draft = state(["A"], {
+      A: group("A", world(100, 50), ["B"]),
+      B: group("B", world(30, 20), ["C"]),
+      C: kozane("C", world(5, 6)),
+    });
+
+    expect(get_total_offset_of_parents(id("B"), draft)).toEqual(
+      world(130, 70)
+    );
+  });
+});

--- a/src/Event/onWheel.tsx
+++ b/src/Event/onWheel.tsx
@@ -1,25 +1,13 @@
-import { add_v2, mul_v2, sub_v2, V2 } from "../dimension/V2";
 import { screen_to_world, TWorldCoord } from "../dimension/world_to_screen";
 import { updateGlobal } from "../Global/updateGlobal";
 import { constants } from "../API/constants";
 import { get_last_mouse_position } from "./onCanvasMouseMove";
 import { kozaneba } from "../API/KozanebaAPI";
-
-function zoomAroundMousePointer(
-  initZoom: number,
-  initCenter: TWorldCoord,
-  zoomCenter: TWorldCoord,
-  scale: number
-): [number, V2] {
-  const v = sub_v2(initCenter, zoomCenter);
-  let newZoom = initZoom * scale;
-  let newCenter = add_v2(initCenter, mul_v2((1 - scale) / scale, v));
-  return [newZoom, newCenter];
-}
+import { zoom_around_world_point } from "../dimension/zoom_around_world_point";
 
 export const zoom_around_pointer = (delta_scale: number) => {
   updateGlobal((g) => {
-    const [newZoom, newCenter] = zoomAroundMousePointer(
+    const [newZoom, newCenter] = zoom_around_world_point(
       g.scale,
       [-g.trans_x, -g.trans_y] as TWorldCoord,
       screen_to_world(get_last_mouse_position()),

--- a/src/dimension/world_to_screen.test.ts
+++ b/src/dimension/world_to_screen.test.ts
@@ -1,0 +1,61 @@
+import {
+  screen_to_world_with_viewport,
+  TScreenCoord,
+  TViewportTransform,
+  TWorldCoord,
+  world_to_screen_with_viewport,
+} from "./world_to_screen";
+
+const screen = (x: number, y: number) => [x, y] as TScreenCoord;
+const world = (x: number, y: number) => [x, y] as TWorldCoord;
+
+const expectWorldCloseTo = (actual: TWorldCoord, expected: TWorldCoord) => {
+  expect(actual[0]).toBeCloseTo(expected[0]);
+  expect(actual[1]).toBeCloseTo(expected[1]);
+};
+
+const expectScreenCloseTo = (actual: TScreenCoord, expected: TScreenCoord) => {
+  expect(actual[0]).toBeCloseTo(expected[0]);
+  expect(actual[1]).toBeCloseTo(expected[1]);
+};
+
+describe("screen/world coordinate conversion", () => {
+  const viewports: TViewportTransform[] = [
+    { width: 800, height: 600, scale: 1, trans_x: 0, trans_y: 0 },
+    { width: 1024, height: 768, scale: 2, trans_x: 100, trans_y: -50 },
+    { width: 375, height: 667, scale: 0.5, trans_x: -200, trans_y: 300 },
+  ];
+
+  const worldPoints = [
+    world(0, 0),
+    world(120, -80),
+    world(-1000.25, 500.5),
+  ];
+
+  test("world_to_screen and screen_to_world are inverse transforms", () => {
+    viewports.forEach((viewport) => {
+      worldPoints.forEach((point) => {
+        const screenPoint = world_to_screen_with_viewport(point, viewport);
+        expectWorldCloseTo(
+          screen_to_world_with_viewport(screenPoint, viewport),
+          point
+        );
+      });
+    });
+  });
+
+  test("applies viewport center, translation, and scale", () => {
+    const viewport = {
+      width: 800,
+      height: 600,
+      scale: 2,
+      trans_x: 10,
+      trans_y: -20,
+    };
+
+    expectScreenCloseTo(
+      world_to_screen_with_viewport(world(5, 30), viewport),
+      screen(430, 320)
+    );
+  });
+});

--- a/src/dimension/world_to_screen.ts
+++ b/src/dimension/world_to_screen.ts
@@ -7,18 +7,49 @@ export type TScreenCoord = Static<typeof RTScreenCoord>;
 export const RTWorldCoord = RT_V2.withBrand("World");
 export type TWorldCoord = Static<typeof RTWorldCoord>;
 
-export const world_to_screen = ([x, y]: TWorldCoord): TScreenCoord => {
-  const g = getGlobal();
+export type TViewportTransform = {
+  width: number;
+  height: number;
+  scale: number;
+  trans_x: number;
+  trans_y: number;
+};
+
+export const world_to_screen_with_viewport = (
+  [x, y]: TWorldCoord,
+  viewport: TViewportTransform
+): TScreenCoord => {
   return [
-    document.body.clientWidth / 2 + (x + g.trans_x) * g.scale,
-    document.body.clientHeight / 2 + (y + g.trans_y) * g.scale,
+    viewport.width / 2 + (x + viewport.trans_x) * viewport.scale,
+    viewport.height / 2 + (y + viewport.trans_y) * viewport.scale,
   ] as TScreenCoord;
 };
 
-export const screen_to_world = ([x, y]: TScreenCoord): TWorldCoord => {
-  const g = getGlobal();
+export const screen_to_world_with_viewport = (
+  [x, y]: TScreenCoord,
+  viewport: TViewportTransform
+): TWorldCoord => {
   return [
-    (x - document.body.clientWidth / 2) / g.scale - g.trans_x,
-    (y - document.body.clientHeight / 2) / g.scale - g.trans_y,
+    (x - viewport.width / 2) / viewport.scale - viewport.trans_x,
+    (y - viewport.height / 2) / viewport.scale - viewport.trans_y,
   ] as TWorldCoord;
+};
+
+const get_current_viewport = (): TViewportTransform => {
+  const g = getGlobal();
+  return {
+    width: document.body.clientWidth,
+    height: document.body.clientHeight,
+    scale: g.scale,
+    trans_x: g.trans_x,
+    trans_y: g.trans_y,
+  };
+};
+
+export const world_to_screen = (point: TWorldCoord): TScreenCoord => {
+  return world_to_screen_with_viewport(point, get_current_viewport());
+};
+
+export const screen_to_world = (point: TScreenCoord): TWorldCoord => {
+  return screen_to_world_with_viewport(point, get_current_viewport());
 };

--- a/src/dimension/zoom_around_world_point.test.ts
+++ b/src/dimension/zoom_around_world_point.test.ts
@@ -1,0 +1,49 @@
+import { TWorldCoord } from "./world_to_screen";
+import {
+  screen_to_world_with_viewport,
+  TScreenCoord,
+  TViewportTransform,
+} from "./world_to_screen";
+import { zoom_around_world_point } from "./zoom_around_world_point";
+
+const screen = (x: number, y: number) => [x, y] as TScreenCoord;
+const world = (x: number, y: number) => [x, y] as TWorldCoord;
+
+const applyZoom = (
+  viewport: TViewportTransform,
+  zoomCenter: TWorldCoord,
+  scale: number
+): TViewportTransform => {
+  const [nextScale, nextCenter] = zoom_around_world_point(
+    viewport.scale,
+    world(-viewport.trans_x, -viewport.trans_y),
+    zoomCenter,
+    scale
+  );
+  return {
+    ...viewport,
+    scale: nextScale,
+    trans_x: -nextCenter[0],
+    trans_y: -nextCenter[1],
+  };
+};
+
+describe("zoom_around_world_point", () => {
+  test("keeps the world point under the cursor stable", () => {
+    const viewport = {
+      width: 800,
+      height: 600,
+      scale: 1,
+      trans_x: 100,
+      trans_y: 50,
+    };
+    const cursor = screen(300, 200);
+    const before = screen_to_world_with_viewport(cursor, viewport);
+
+    const nextViewport = applyZoom(viewport, before, 2);
+    const after = screen_to_world_with_viewport(cursor, nextViewport);
+
+    expect(after[0]).toBeCloseTo(before[0]);
+    expect(after[1]).toBeCloseTo(before[1]);
+  });
+});

--- a/src/dimension/zoom_around_world_point.ts
+++ b/src/dimension/zoom_around_world_point.ts
@@ -1,0 +1,14 @@
+import { add_v2, mul_v2, sub_v2, V2 } from "./V2";
+import { TWorldCoord } from "./world_to_screen";
+
+export function zoom_around_world_point(
+  initZoom: number,
+  initCenter: TWorldCoord,
+  zoomCenter: TWorldCoord,
+  scale: number
+): [number, V2] {
+  const v = sub_v2(initCenter, zoomCenter);
+  const newZoom = initZoom * scale;
+  const newCenter = add_v2(initCenter, mul_v2((1 - scale) / scale, v));
+  return [newZoom, newCenter];
+}


### PR DESCRIPTION
## Summary
- extract pure helpers for screen/world coordinate conversion and zoom-around-point math
- extract parent-change position math used by nested group drops
- add unit tests for supplied-state parent traversal, root-to-nested parent chain offsets, A(B(C)) world-coordinate stability, screen/world inversion, and zoom cursor stability

## Validation
- npm test -- --watchAll=false
- npm run build
- npm run codex:preflight

## Notes
This is Step 1 of the test improvement plan: turn the nested drag fix knowledge into deterministic unit tests before making the broader CI gate required.