### PR TITLE
Add Kozaneba CI workflow

### DIFF
--- a/.github/workflows/kozaneba-ci.yml
+++ b/.github/workflows/kozaneba-ci.yml
@@ -1,0 +1,80 @@
+name: Kozaneba CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: kozaneba-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-build-preflight:
+    name: Unit, build, and preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Verify Cypress binary
+        run: npx cypress verify
+
+      - name: Unit tests
+        run: npm test -- --watchAll=false
+
+      - name: Production build
+        run: npm run build
+
+      - name: Codex preflight
+        run: npm run codex:preflight
+
+  cypress-emulator:
+    name: Cypress with Firebase emulator
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Verify Firebase CLI and Cypress
+        run: |
+          npx firebase --version
+          npx cypress verify
+
+      - name: Firebase emulator smoke
+        run: npm run cypress:emulator-smoke
+
+      - name: Kozaneba Cypress suite
+        run: npm run cypress:kozaneba-all

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test": "react-scripts test",
     "codex:preflight": "bash scripts/codex-preflight.sh",
     "cypress:emulator-smoke": "bash scripts/cypress-emulator-smoke.sh",
+    "cypress:kozaneba-all": "bash scripts/cypress-kozaneba-all.sh",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/scripts/cypress-kozaneba-all.sh
+++ b/scripts/cypress-kozaneba-all.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_URL="${CYPRESS_BASE_URL:-http://localhost:3000}"
+STARTED_SERVER=0
+SERVER_LOG="$(mktemp -t kozaneba-cypress-all-server.XXXXXX.log)"
+
+cleanup() {
+  if [[ "$STARTED_SERVER" == "1" && "${SERVER_PID:-}" != "" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+cd "$ROOT"
+
+section() {
+  printf "\n== %s ==\n" "$1"
+}
+
+wait_for_server() {
+  local i
+  for i in {1..90}; do
+    if curl -fsS "$BASE_URL/#blank" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Dev server did not become reachable at $BASE_URL" >&2
+  echo "Server log: $SERVER_LOG" >&2
+  return 1
+}
+
+section "Environment"
+node --version
+npm --version
+npx firebase --version
+
+section "Dev server"
+if curl -fsS "$BASE_URL/#blank" >/dev/null 2>&1; then
+  echo "Using existing dev server at $BASE_URL"
+else
+  echo "Starting dev server at $BASE_URL"
+  env -u ELECTRON_RUN_AS_NODE BROWSER=none npm start >"$SERVER_LOG" 2>&1 &
+  SERVER_PID=$!
+  STARTED_SERVER=1
+  wait_for_server
+fi
+
+section "Kozaneba Cypress"
+env -u ELECTRON_RUN_AS_NODE npx firebase emulators:exec --only auth,firestore \
+  "env -u ELECTRON_RUN_AS_NODE npx cypress run \
+    --spec 'cypress/e2e/kozaneba/*.cy.ts' \
+    --config baseUrl=$BASE_URL,video=false"
+
+section "Done"
+echo "Kozaneba Cypress suite passed."


### PR DESCRIPTION
## Summary
- add a Kozaneba CI GitHub Actions workflow for unit tests, production build, Codex preflight, Firebase emulator smoke, and the Kozaneba Cypress suite
- add `npm run cypress:kozaneba-all` to run `cypress/e2e/kozaneba/*.cy.ts` with Auth and Firestore emulators
- pin CI to Node 22 and Java 21 so `firebase-tools@15` can run the emulator

## Validation
- bash -n scripts/cypress-kozaneba-all.sh
- Ruby YAML parse for `.github/workflows/kozaneba-ci.yml`
- npm test -- --watchAll=false
- npm run build
- npm run codex:preflight

## Notes
Local Java is 19, so the Firebase emulator suite is expected to be verified by this PR's Java 21 CI job.