### PR TITLE
Clean up Vite environment usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "web-vitals": "^3.5.2"
       },
       "devDependencies": {
-        "@types/node": "^16.3.1",
+        "@types/node": "^24.9.0",
         "@vitejs/plugin-react": "^6.0.2",
         "cypress": "^13.17.0",
         "firebase-tools": "^15.19.0",
@@ -4132,10 +4132,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
-      "license": "MIT"
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.0.tgz",
+      "integrity": "sha512-MKNwXh3seSK8WurXF7erHPJ2AONmMwkI7zAMrXZDPIru8jRqkk6rGDBVbw4mLwfqA+ZZliiDPg05JQ3uW66tKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
@@ -14018,6 +14021,12 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "^16.3.1",
+    "@types/node": "^24.9.0",
     "@vitejs/plugin-react": "^6.0.2",
     "cypress": "^13.17.0",
     "firebase-tools": "^15.19.0",

--- a/src/Physics/physics.ts
+++ b/src/Physics/physics.ts
@@ -125,7 +125,7 @@ export const step = () => {
   redraw();
 };
 
-let timer: null | NodeJS.Timer = null;
+let timer: ReturnType<typeof setInterval> | null = null;
 export const toggle_physics = () => {
   if (timer === null) {
     gradient_method = new GradientDecent();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ const initDevelopment = () => {
 
 setGlobal(INITIAL_GLOBAL_STATE);
 
-if (process.env.NODE_ENV !== "production") {
+if (import.meta.env.DEV) {
   initDevelopment();
 } else {
   initProduction();
@@ -53,7 +53,4 @@ root.render(
   //  </React.StrictMode>
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -1,7 +1,7 @@
 export const _dummy: number[] = [];
 
 export const dev_make_heavy = () => {
-  if (process.env.NODE_ENV === "production") return;
+  if (import.meta.env.PROD) return;
 
   const N = 1000;
   for (let i = 0; i < N; i++) {
@@ -13,16 +13,16 @@ export const dev_make_heavy = () => {
 };
 
 export const dev_log = (...args: any[]) => {
-  if (process.env.NODE_ENV === "production") return;
+  if (import.meta.env.PROD) return;
   console.log.apply(console, args);
 };
 
 export const dev_time = (label: string) => {
-  if (process.env.NODE_ENV === "production") return;
+  if (import.meta.env.PROD) return;
   console.time.apply(console, [label]);
 };
 
 export const dev_time_end = (label: string) => {
-  if (process.env.NODE_ENV === "production") return;
+  if (import.meta.env.PROD) return;
   console.timeEnd.apply(console, [label]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,10 +1689,12 @@
     "@types/node" "*"
     form-data "^4.0.0"
 
-"@types/node@*", "@types/node@^16.3.1", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "16.18.11"
-  resolved "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz"
-  integrity sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==
+"@types/node@*", "@types/node@^24.9.0", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
+  version "24.9.0"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.9.0.tgz"
+  integrity sha512-MKNwXh3seSK8WurXF7erHPJ2AONmMwkI7zAMrXZDPIru8jRqkk6rGDBVbw4mLwfqA+ZZliiDPg05JQ3uW66tKQ==
+  dependencies:
+    undici-types "~7.16.0"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -7098,6 +7100,11 @@ typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@^6.25.0:
   version "6.26.0"


### PR DESCRIPTION
## Summary
- replace remaining app-side `process.env.NODE_ENV` checks with Vite `import.meta.env` flags
- align `@types/node` with the Node 24 runtime
- use `ReturnType<typeof setInterval>` for the physics timer so Node 24 types and DOM timers both type-check

## Verification
- `npm test`
- `npm run build`
- `npm run codex:preflight`
- `npm audit --audit-level=moderate`

Notes: the Vite build still emits the existing direct `eval` and bundle-size warnings; they are warnings, not failures.