### PR TITLE
Route production console logs through dev logger

### DIFF
--- a/src/API/run_user_script.ts
+++ b/src/API/run_user_script.ts
@@ -1,10 +1,12 @@
+import { dev_log } from "../utils/dev";
+
 export const run_user_script = () => {
   const user_script = localStorage.getItem("onLoad");
   if (user_script === null) {
     return;
   }
 
-  console.log("Running user script:\n```\n" + user_script + "\n```");
+  dev_log("Running user script:\n```\n" + user_script + "\n```");
   try {
     // eslint-disable-next-line no-eval
     eval(user_script);

--- a/src/App/Edit.tsx
+++ b/src/App/Edit.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from "react";
 import { updateGlobal } from "../Global/updateGlobal";
+import { dev_log } from "../utils/dev";
 import { Blank } from "./Blank";
 
 export const Edit: React.FC<{ ba: string }> = ({ ba }) => {
   useEffect(() => {
-    console.log("loading", ba);
+    dev_log("loading", ba);
     updateGlobal((g) => {
       g.statusBar.type = "downloading";
       g.dialog = "Loading";

--- a/src/App/hotKey.ts
+++ b/src/App/hotKey.ts
@@ -4,6 +4,7 @@ import { constants } from "../API/constants";
 import { toggle_fit_to_contents } from "./toggle_fit_to_contents";
 import { moveCenter } from "../utils/moveCenter";
 import { open_dialog } from "../utils/open_dialog";
+import { dev_log } from "../utils/dev";
 
 export const hotKey = (e: KeyboardEvent) => {
   const g = getGlobal();
@@ -48,7 +49,7 @@ export const hotKey = (e: KeyboardEvent) => {
     zoom_out_pointer();
     e.preventDefault();
   } else {
-    console.log(e);
+    dev_log(e);
   }
 };
 export const finishButtons = {} as { [dialogName: string]: () => void };

--- a/src/App/toggle_fit_to_contents.ts
+++ b/src/App/toggle_fit_to_contents.ts
@@ -1,11 +1,12 @@
 import { getGlobal, setGlobal } from "reactn";
+import { dev_log } from "../utils/dev";
 import { fit_to_contents } from "../utils/fit_to_contents";
 
 let prev_view = { scale: 1, trans_x: 0, trans_y: 0 };
 
 export const toggle_fit_to_contents = () => {
   const new_view = fit_to_contents(undefined, false) ?? prev_view;
-  console.log("new_view:", new_view);
+  dev_log("new_view:", new_view);
   const g = getGlobal();
   if (
     new_view.scale === g.scale &&
@@ -13,12 +14,9 @@ export const toggle_fit_to_contents = () => {
     new_view.trans_y === g.trans_y
   ) {
     // if already fit to contents, recover previous view
-    // console.log("recover previous view", prev_view);
     setGlobal(prev_view);
   } else {
     prev_view = { scale: g.scale, trans_x: g.trans_x, trans_y: g.trans_y };
-    // console.log("new prev_view", prev_view);
-    // console.log("fit to contents", new_view);
     setGlobal(new_view);
   }
 };

--- a/src/Canvas/Annotation/LineAnnot.tsx
+++ b/src/Canvas/Annotation/LineAnnot.tsx
@@ -23,6 +23,7 @@ import { TLineAnnot } from "../../Global/TAnnotation";
 import { TItemId } from "../../Global/TItemId";
 import { updateGlobal } from "../../Global/updateGlobal";
 import { find_parent } from "../../utils/find_parent";
+import { dev_log } from "../../utils/dev";
 import { KOZANE_WIDTH } from "../../utils/kozane_constants";
 import { mark_local_changed } from "../../utils/mark_local_changed";
 import { get_box_line_crosspoint } from "./get_box_line_crosspoint";
@@ -92,7 +93,7 @@ export const LineAnnot = (g: State, a: TLineAnnot, annot_index: number) => {
       return bounding_box_to_rect(get_item_bounding_box(id));
     }
     const offset = get_total_offset_of_parents(parent, g);
-    console.log({ offset });
+    dev_log({ offset });
     const { top, left, width, height } = bounding_box_to_rect(
       get_item_bounding_box(id)
     );

--- a/src/Canvas/Annotation/get_box_line_crosspoint.tsx
+++ b/src/Canvas/Annotation/get_box_line_crosspoint.tsx
@@ -2,8 +2,6 @@ import { TRect } from "../../dimension/TRect";
 import { sub_v2, V2 } from "../../dimension/V2";
 
 export const get_box_line_crosspoint = (start: V2, end: V2, box: TRect): V2 => {
-  // console.log({ start, end, box });
-
   // box is around the start point
   const [x, y] = start;
   const [dx, dy] = sub_v2(end, start);

--- a/src/Cloud/FirestoreIO.ts
+++ b/src/Cloud/FirestoreIO.ts
@@ -8,6 +8,7 @@ import { TGyazoItem } from "../Global/TGyazoItem";
 import { TKozaneItem } from "../Global/TKozaneItem";
 import { TGroupItem } from "../Global/TGroupItem";
 import { upgrade } from "../utils/piece_to_kozane";
+import { dev_log } from "../utils/dev";
 import { DocData, DocRef } from "./FirebaseShortTypename";
 import { auth, db } from "./init_firebase";
 
@@ -22,7 +23,7 @@ auth.onAuthStateChanged((user) => {
 export const authui = new firebaseui.auth.AuthUI(auth);
 
 export const showCurrentUser = () => {
-  console.log(auth.currentUser);
+  dev_log(auth.currentUser);
 };
 
 export const load_from_server = (data: DocData): void => {};

--- a/src/Cloud/initial_save.ts
+++ b/src/Cloud/initial_save.ts
@@ -6,9 +6,10 @@ import { set_status } from "../utils/set_status";
 import { save_new } from "./save_new";
 import { not_login_then_show_dialog } from "./not_login_then_show_dialog";
 import { get_user_id } from "./get_user_id";
+import { dev_log } from "../utils/dev";
 
 export const initial_save = () => {
-  console.log("initial save");
+  dev_log("initial save");
   if (not_login_then_show_dialog()) return;
   close_menu();
   set_status("uploading");

--- a/src/Cloud/not_login_then_show_dialog.ts
+++ b/src/Cloud/not_login_then_show_dialog.ts
@@ -1,4 +1,5 @@
 import { updateGlobal } from "../Global/updateGlobal";
+import { dev_log } from "../utils/dev";
 import { auth } from "./init_firebase";
 
 export const not_login_then_show_dialog = () => {
@@ -6,9 +7,9 @@ export const not_login_then_show_dialog = () => {
     updateGlobal((g) => {
       g.dialog = "CloudSave";
     });
-    console.log(`not login. show dialog.`);
+    dev_log(`not login. show dialog.`);
     return true;
   }
-  console.log(`save as ${auth.currentUser.displayName ?? "Anonymous"}`);
+  dev_log(`save as ${auth.currentUser.displayName ?? "Anonymous"}`);
   return false;
 };

--- a/src/Cloud/save.ts
+++ b/src/Cloud/save.ts
@@ -7,10 +7,11 @@ import { if_not_in_writer_add_self } from "./if_not_in_writer_add_self";
 import { not_login_then_show_dialog } from "./not_login_then_show_dialog";
 import { set_status } from "../utils/set_status";
 import { local_db } from "./LocalBackup";
+import { dev_log } from "../utils/dev";
 
 
 export const save = () => {
-  console.log("update save");
+  dev_log("update save");
   if (not_login_then_show_dialog()) return;
   set_status("uploading");
   if_not_in_writer_add_self();

--- a/src/Cloud/set_up_read_subscription.tsx
+++ b/src/Cloud/set_up_read_subscription.tsx
@@ -5,16 +5,17 @@ import { docdate_to_state } from "./FirestoreIO";
 import { db } from "./init_firebase";
 import { DocSnap } from "./FirebaseShortTypename";
 import { set_status } from "../utils/set_status";
+import { dev_log } from "../utils/dev";
 
 let unsubscribe = null as null | (() => void);
 
 export const set_up_read_subscription = (ba: string) => {
-  console.log("set_up_read_subscription", ba);
+  dev_log("set_up_read_subscription", ba);
   unsubscribe = db.collection("ba").doc(ba).onSnapshot((doc: DocSnap) => {
       const data = doc.data();
       if (data === undefined) {
         // throw new TypeError("doc.data() is undefined");
-        console.log("doc.data() is undefined. disconnecting");
+        dev_log("doc.data() is undefined. disconnecting");
         updateGlobal((g) => {
           g.cloud_ba = "";
           g.statusBar.type = "no-connection";
@@ -23,17 +24,17 @@ export const set_up_read_subscription = (ba: string) => {
         return;
       }
 
-      console.log("new data from server");
+      dev_log("new data from server");
       const server = docdate_to_state(data);
       const local_latest = getGlobal().last_updated;
       if (data.last_updated > local_latest) {
-        console.log("update local with data from server", server);
+        dev_log("update local with data from server", server);
         setGlobal(server);
         setGlobal(fit_to_contents());
       } else if (data.last_updated < local_latest) {
         throw new Error("received old data from server (warning)"); // it happens?
       } else {
-        console.log("no need to update");
+        dev_log("no need to update");
       }
       set_status("done");
     });
@@ -41,9 +42,9 @@ export const set_up_read_subscription = (ba: string) => {
 };
 
 export const stop_current_subscription = () => {
-  console.log("stop_current_subscription");
+  dev_log("stop_current_subscription");
   if (unsubscribe === null) {
-    console.log("no current subscription");
+    dev_log("no current subscription");
   } else {
     unsubscribe();
   }

--- a/src/Cloud/signInAsAnonymousUser.tsx
+++ b/src/Cloud/signInAsAnonymousUser.tsx
@@ -1,9 +1,10 @@
 import { auth } from "./init_firebase";
+import { dev_log } from "../utils/dev";
 
 
 export const signInAsAnonymousUser = () => {
-  console.log("signInAsAnonymousUser");
+  dev_log("signInAsAnonymousUser");
   return auth.signInAnonymously().then(() => {
-    console.log("done");
+    dev_log("done");
   });
 };

--- a/src/Dialog/AddKozaneDialog/AddKozaneDialog.tsx
+++ b/src/Dialog/AddKozaneDialog/AddKozaneDialog.tsx
@@ -11,6 +11,7 @@ import { constants } from "../../API/constants";
 import { finishButtons } from "../../App/hotKey";
 import { addTooltip } from "../../utils/addTooltip";
 import { add_multiple_kozane } from "../../utils/add_multiple_kozane";
+import { dev_log } from "../../utils/dev";
 
 export const AddKozaneDialog = () => {
   const [dialog, setDialog] = useGlobal("dialog");
@@ -24,7 +25,7 @@ export const AddKozaneDialog = () => {
   };
 
   const onAddKozane = () => {
-    console.log("onAddKozane", open, textarea.current);
+    dev_log("onAddKozane", open, textarea.current);
     if (textarea.current === null) return;
     if (!open) return;
     let multiline = textarea.current.value;

--- a/src/Dialog/BaDialog.tsx
+++ b/src/Dialog/BaDialog.tsx
@@ -15,6 +15,7 @@ import { mark_local_changed } from "../utils/mark_local_changed";
 import { delete_ba } from "../Cloud/delete_ba";
 import { can_write, is_cloud } from "../utils/can_write";
 import { make_copy } from "../utils/make_copy";
+import { dev_log } from "../utils/dev";
 
 export type Ba = { title: string; id: string; last_updated: number };
 
@@ -112,9 +113,9 @@ const Share: React.FC<{ mode: string }> = ({ mode }) => {
   const share_url = `https://kozaneba.netlify.app/#${mode}=${cloud_ba}`;
   const onChange = (e: SelectChangeEvent<string>) => {
     const value = e.target.value;
-    console.log(e);
+    dev_log(e);
     const anyone_writable = value === "edit";
-    console.log(anyone_writable);
+    dev_log(anyone_writable);
     setGlobal({ anyone_writable });
     mark_local_changed();
   };

--- a/src/Dialog/CloudSaveDialog.tsx
+++ b/src/Dialog/CloudSaveDialog.tsx
@@ -13,12 +13,13 @@ import { close_menu_and_dialog } from "../utils/close_menu";
 import { initial_save } from "../Cloud/initial_save";
 import { useEffect } from "react";
 import { GoogleAuthProvider } from "../Cloud/init_firebase";
+import { dev_log } from "../utils/dev";
 
 export const CloudSaveDialog = () => {
   const [dialog] = useGlobal("dialog");
   const open = dialog === "CloudSave";
   useEffect(() => {
-    console.log("CloudSaveDialog open:", open);
+    dev_log("CloudSaveDialog open:", open);
   }, [open]);
 
   const onClose = () => {

--- a/src/Dialog/Tutorial/TutorialDialog.tsx
+++ b/src/Dialog/Tutorial/TutorialDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from "@mui/material";
 import { close_menu_and_dialog } from "../../utils/close_menu";
+import { dev_log } from "../../utils/dev";
 import { tutorial_pages } from "./tutorial_pages";
 import { useEffect } from "react";
 // import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -25,7 +26,7 @@ export const TutorialDialog = () => {
     close_menu_and_dialog();
   };
   useEffect(() => {
-    console.log(`Tutorial Page: ${p} open: ${open}`);
+    dev_log(`Tutorial Page: ${p} open: ${open}`);
   }, [p, open]);
 
   let page = tutorial_pages[p]!;

--- a/src/Dialog/User/UserScriptDialog.tsx
+++ b/src/Dialog/User/UserScriptDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { useRef, useState } from "react";
 import { useGlobal } from "reactn";
 import { close_menu_and_dialog } from "../../utils/close_menu";
+import { dev_log } from "../../utils/dev";
 
 export type Ba = { title: string; id: string; last_updated: number };
 
@@ -24,17 +25,17 @@ export const UserScriptDialog = () => {
 
   const onRun = () => {
     try {
-      console.log("Run UserScript");
+      dev_log("Run UserScript");
       // eslint-disable-next-line no-eval
       eval(ref.current!.value);
-      console.log("OK");
+      dev_log("OK");
     } catch (error) {
       console.error(error);
     }
   };
   const onSave = () => {
     localStorage.setItem("onLoad", ref.current!.value);
-    console.log("Saved");
+    dev_log("Saved");
   };
   const onSample = () => {
     window.open(

--- a/src/Event/drag_drop_item.ts
+++ b/src/Event/drag_drop_item.ts
@@ -24,7 +24,7 @@ export function drag_drop_item(
   dev_log("drag_drop_item", target_id, delta);
   const parent = find_parent(target_id);
   if (parent !== null) {
-    console.log(`move target ${target_id} out from parent ${parent} to top`);
+    dev_log(`move target ${target_id} out from parent ${parent} to top`);
     updateGlobal((g) => {
       const p = get_group(g, parent);
       p.items = remove_item_from(p.items, target_id);
@@ -43,7 +43,7 @@ export function drag_drop_item(
       }
     });
   } else {
-    console.log(`move target ${target_id} from top to top`);
+    dev_log(`move target ${target_id} from top to top`);
     move_front(target_id);
     updateGlobal((g) => {
       const x = get_item(g, target_id);

--- a/src/Event/drag_drop_selection_into_group.ts
+++ b/src/Event/drag_drop_selection_into_group.ts
@@ -8,12 +8,13 @@ import { get_group } from "../utils/get_group";
 import { get_item } from "../utils/get_item";
 import { TWorldCoord } from "../dimension/world_to_screen";
 import { TItemId } from "../Global/TItemId";
+import { dev_log } from "../utils/dev";
 
 export function drag_drop_selection_into_group(
   group_id: TItemId,
   delta: TWorldCoord
 ) {
-  console.log("selection drop on group", group_id);
+  dev_log("selection drop on group", group_id);
   updateGlobal((g) => {
     const group_draft = get_group(g, group_id);
     g.selected_items.forEach((id) => {

--- a/src/Event/mouseEventMamager.ts
+++ b/src/Event/mouseEventMamager.ts
@@ -1,13 +1,14 @@
 import React from "react";
 import { screen_to_world } from "../dimension/world_to_screen";
 import { updateGlobal } from "../Global/updateGlobal";
+import { dev_log } from "../utils/dev";
 import { set_target } from "./fast_drag_manager";
 import { get_client_pos } from "./get_client_pos";
 
 export const onSelectionMouseDown = (
   event: React.MouseEvent<HTMLDivElement>
 ) => {
-  console.log("onSelectionMouseDown");
+  dev_log("onSelectionMouseDown");
   set_target(event);
   updateGlobal((g) => {
     g.dragstart_position = screen_to_world(get_client_pos(event));

--- a/src/Event/onCanvasMouseUp.ts
+++ b/src/Event/onCanvasMouseUp.ts
@@ -5,13 +5,14 @@ import { get_delta } from "./get_delta";
 import { finish_selecting } from "./finish_selecting";
 import { drag_drop_selection } from "./drag_drop_selection";
 import { drag_drop_item } from "./drag_drop_item";
+import { dev_log } from "../utils/dev";
 import { moveCenter } from "../utils/moveCenter";
 import { handle_making_line } from "./handle_making_line";
 
 export const onCanvasMouseUp = (
   event: React.MouseEvent<HTMLDivElement, MouseEvent>
 ) => {
-  console.log("onCanvasMouseUp");
+  dev_log("onCanvasMouseUp");
   if (handle_if_is_click(event)) return;
 
   const g = getGlobal();

--- a/src/Event/onGenericClick.ts
+++ b/src/Event/onGenericClick.ts
@@ -30,7 +30,7 @@ export const onGenericClick = (
   });
   reset_target();
 
-  console.log(`onGenericClick type:${target.type} id:${id}`);
+  dev_log(`onGenericClick type:${target.type} id:${id}`);
   if (target.type === "kozane") {
     show_menu("Kozane", event);
     return true;

--- a/src/Event/onGroupMouseUp.ts
+++ b/src/Event/onGroupMouseUp.ts
@@ -40,7 +40,7 @@ export const onGroupMouseUp = (
     dev_log(`target_id === ${target_id}`);
     drag_drop_item_into_group(group_id, delta, target_id);
   } else {
-    console.log("unexpected behavior", group_id);
+    dev_log("unexpected behavior", group_id);
 
     throw new Error();
   }

--- a/src/Event/onWheel.tsx
+++ b/src/Event/onWheel.tsx
@@ -4,6 +4,7 @@ import { constants } from "../API/constants";
 import { get_last_mouse_position } from "./onCanvasMouseMove";
 import { kozaneba } from "../API/KozanebaAPI";
 import { zoom_around_world_point } from "../dimension/zoom_around_world_point";
+import { dev_log } from "../utils/dev";
 
 export const zoom_around_pointer = (delta_scale: number) => {
   updateGlobal((g) => {
@@ -41,7 +42,7 @@ export const onWheel = (e: WheelEvent) => {
   count++;
   const now = Date.now();
   if (now > prevTiming + 1000) {
-    console.log(`count: ${count - prevCount}, time: ${now - prevTiming}`);
+    dev_log(`count: ${count - prevCount}, time: ${now - prevTiming}`);
     prevCount = count;
     prevTiming = now;
   }

--- a/src/Global/exposeGlobal.ts
+++ b/src/Global/exposeGlobal.ts
@@ -6,6 +6,7 @@ import { closeGroup } from "../Group/closeGroup";
 import { KozaneItem } from "../Kozane/KozaneItem";
 import { importRegroupJSON } from "../Regroup/importRegroupJSON";
 import { reset_selection } from "../Selection/reset_selection";
+import { dev_log } from "../utils/dev";
 import { make_items_into_new_group } from "../utils/make_items_into_new_group";
 import { kintone_demo } from "./kintone_demo";
 import { TKozaneItem } from "./TKozaneItem";
@@ -15,13 +16,13 @@ let isFirestoreEmulatorConnected = false;
 let isAuthEmulatorConnected = false;
 
 const tmpfunc = () => {
-  console.log("write");
+  dev_log("write");
   db.collection("ba").doc("foo").set({ x: "hello" })
     .then(() => {
-      console.log("OK");
+      dev_log("OK");
     })
     .catch((err: Error) => {
-      console.log(err);
+      dev_log(err);
     });
 };
 export const toUseEmulator = () => {

--- a/src/Global/kintone_demo.ts
+++ b/src/Global/kintone_demo.ts
@@ -1,5 +1,6 @@
 import { create_squared_position } from "../dimension/create_squared_position";
 import { get_center_of_screen } from "../dimension/get_center_of_screen";
+import { dev_log } from "../utils/dev";
 import { GroupItem } from "../Group/GroupItem";
 import { KozaneItem } from "../Kozane/KozaneItem";
 import { TItem } from "./TItem";
@@ -17,7 +18,7 @@ export const kintone_demo = (
   })
     .then((res) => res.json())
     .then((records) => {
-      console.log(records);
+      dev_log(records);
 
       // from create_squared_group
       const positions = create_squared_position(records);

--- a/src/Kozane/parse_as_scrapbox.tsx
+++ b/src/Kozane/parse_as_scrapbox.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { getGlobal } from "reactn";
 import { TKozaneItem } from "../Global/TKozaneItem";
 import { make_scrapbox_url } from "../Scrapbox/make_scrapbox_kozane";
+import { dev_log } from "../utils/dev";
 
 export const build_content = (value: TKozaneItem) => {
   const g = getGlobal();
@@ -23,10 +24,10 @@ export const build_content = (value: TKozaneItem) => {
           const src = `https://scrapbox.io/api/pages/${node.path}/icon`;
           return <img src={src} style={{ height: "1em" }} alt={node.path} />;
         } else {
-          console.log(node);
+          dev_log(node);
         }
       } else if (node.type === "link") {
-        console.log(node);
+        dev_log(node);
         if (node.pathType === "relative") {
           // const src = `https://scrapbox.io/${proj}/${node.href}`;
           // return <a href={src}> {node.raw} </a>;
@@ -40,11 +41,11 @@ export const build_content = (value: TKozaneItem) => {
           // return <a href={src}> {node.raw} </a>;
           return <span style={{ color: "blue" }}>[URL]</span>;
         } else {
-          console.log(node);
+          dev_log(node);
           return node.raw;
         }
       } else {
-        console.log(node);
+        dev_log(node);
         return node.raw;
       }
       return null;
@@ -62,7 +63,7 @@ export const get_scarpbox_links = (value: TKozaneItem) => {
 
     line.nodes.forEach((node) => {
       if (node.type === "link") {
-        console.log(node);
+        dev_log(node);
         if (node.pathType === "relative") {
           const url = make_scrapbox_url(
             `https://scrapbox.io/${proj}`,

--- a/src/Menu/copy_json.ts
+++ b/src/Menu/copy_json.ts
@@ -3,6 +3,7 @@ import { get_item } from "../utils/get_item";
 import { TItemId } from "../Global/TItemId";
 import { TItem } from "../Global/TItem";
 import { TAnnotation, TArrowHead } from "../Global/TAnnotation";
+import { dev_log } from "../utils/dev";
 
 type InType = "selection" | "all" | TItemId[];
 const out = { console: true, clipboard: true };
@@ -66,7 +67,7 @@ export const copy_json = (
   });
 
   if (out_type.console) {
-    console.log(json);
+    dev_log(json);
   }
   if (out_type.clipboard) {
     navigator.clipboard.writeText(json);

--- a/src/Menu/copy_text.ts
+++ b/src/Menu/copy_text.ts
@@ -3,6 +3,7 @@ import { bounding_box_to_rect } from "../dimension/bounding_box_to_rect";
 import { get_item_bounding_box } from "../dimension/get_bounding_box";
 import { L2norm, sub_v2 } from "../dimension/V2";
 import { TItemId } from "../Global/TItemId";
+import { dev_log } from "../utils/dev";
 import { get_item } from "../utils/get_item";
 import { KOZANE_HEIGHT, KOZANE_WIDTH } from "../utils/kozane_constants";
 
@@ -96,7 +97,7 @@ const sort_items_for_next_item = (items: TItemId[]): TItemId[] => {
   const get_cost = (id: TItemId) => {
     const item = get_item(g, id);
     const cost = item.position[0] + item.position[1] * 4;
-    console.log(item.text, cost);
+    dev_log(item.text, cost);
     return cost;
   };
 
@@ -110,7 +111,7 @@ export const cluster_to_chain = (items: TItemId[]): TItemId[][] => {
   const g = getGlobal();
 
   const visit = (current: TItemId, chain: TItemId[]) => {
-    console.log("visit", get_item(g, current).text);
+    dev_log("visit", get_item(g, current).text);
     chain.push(current);
     visited[current] = true;
     const next_items = [] as TItemId[];
@@ -119,9 +120,9 @@ export const cluster_to_chain = (items: TItemId[]): TItemId[][] => {
         next_items.push(next);
       }
     });
-    console.log("next_items", next_items);
+    dev_log("next_items", next_items);
     sort_items_for_next_item(next_items).forEach((next) => {
-      console.log("next", get_item(g, next).text);
+      dev_log("next", get_item(g, next).text);
       if (visited[next] !== true) {
         visit(next, chain);
       }
@@ -129,7 +130,7 @@ export const cluster_to_chain = (items: TItemId[]): TItemId[][] => {
   };
 
   sort_items_from_left_top(items).forEach((start) => {
-    console.log("start", get_item(g, start).text);
+    dev_log("start", get_item(g, start).text);
     if (visited[start] === true) {
       return;
     }
@@ -172,11 +173,11 @@ export const items_to_lines = (items: TItemId[]): string[] => {
 
 export const copy_text = () => {
   const ret = items_to_lines(getGlobal().selected_items).join("\n");
-  console.log(ret);
+  dev_log(ret);
   navigator.clipboard.writeText(ret);
 };
 
 // @ts-ignore
 window.copy_text = () => {
-  console.log(items_to_lines(getGlobal().drawOrder).join("\n"));
+  dev_log(items_to_lines(getGlobal().drawOrder).join("\n"));
 };

--- a/src/Menu/copy_text_old.ts
+++ b/src/Menu/copy_text_old.ts
@@ -3,6 +3,7 @@ import { L1norm, L2norm, V2 } from "../dimension/V2";
 import { get_item } from "../utils/get_item";
 import { TItemId } from "../Global/TItemId";
 import { TItem } from "../Global/TItem";
+import { dev_log } from "../utils/dev";
 import { KOZANE_HEIGHT, KOZANE_WIDTH } from "../utils/kozane_constants";
 import { remove_item_from } from "../utils/remove_item_from";
 
@@ -152,7 +153,7 @@ const get_chain = (items: TItemId[], out: Buffer): [TItemId[], TItemId[]] => {
     side_chain.delete(cur);
     result.push(cur);
     const item = get_item(g, cur);
-    console.log(item.text);
+    dev_log(item.text);
     push(item, out);
     const neighbors = get_neighbors(item.position, items);
     if (neighbors.length === 1) {
@@ -163,7 +164,7 @@ const get_chain = (items: TItemId[], out: Buffer): [TItemId[], TItemId[]] => {
         // finish
         return [result, items];
       } else {
-        console.log("no-neighbor chain break");
+        dev_log("no-neighbor chain break");
         out.newline();
         cur = get_left_top(Array.from(side_chain));
       }
@@ -181,7 +182,7 @@ export const copy_text = () => {
   let items = getGlobal().selected_items;
   const out = new Buffer();
   serialize(items, out);
-  console.log(out.concat());
+  dev_log(out.concat());
   navigator.clipboard.writeText(out.concat());
 };
 
@@ -192,7 +193,7 @@ const serialize = (items: TItemId[], out: Buffer) => {
   while (items.length > 0) {
     let [, new_items] = get_chain(items, out);
     items = new_items;
-    console.log("chain break");
+    dev_log("chain break");
     out.newline();
   }
 };
@@ -200,5 +201,5 @@ const serialize = (items: TItemId[], out: Buffer) => {
 window.test = () => {
   const out = new Buffer();
   serialize(getGlobal().drawOrder, out);
-  console.log(out.concat());
+  dev_log(out.concat());
 };

--- a/src/Physics/LineSpring.ts
+++ b/src/Physics/LineSpring.ts
@@ -49,12 +49,10 @@ export const LineSpring: PhysicalLaw = (g) => {
     a.items.forEach((old_id, index) => {
       const v = sub_v2(gp, positions[index]!);
       const n = L2norm(v);
-      // console.log("n", n);
       if (n > NL) {
         add(grad, targets[index]!, mul_v2(n - NL, normalize(v)));
       }
     });
   });
-  // console.log("LineSpring grad", grad);
   return grad;
 };

--- a/src/Physics/physics.ts
+++ b/src/Physics/physics.ts
@@ -5,6 +5,7 @@ import { add_v2, L2norm, mul_v2, normalize, V2 } from "../dimension/V2";
 import { TWorldCoord } from "../dimension/world_to_screen";
 import { TItemId } from "../Global/TItemId";
 import { updateGlobal } from "../Global/updateGlobal";
+import { dev_time, dev_time_end } from "../utils/dev";
 import { ItemRepulse } from "./ItemRepulse";
 import { LineSpring } from "./LineSpring";
 import { pin } from "./pin";
@@ -58,9 +59,6 @@ class AdaDelta {
         mul_v2(1 - this.gamma, square(delta[key]!))
       );
     });
-    // console.log("MSG", this.mean_squared_gradient);
-    // console.log("MSD", this.mean_squared_delta);
-
     return delta;
   }
 }
@@ -98,7 +96,7 @@ interface IGradientMethod {
 let gradient_method: IGradientMethod = new GradientDecent();
 
 export const step = () => {
-  console.time("Physics step");
+  dev_time("Physics step");
   [1, 2].forEach(() => {
     const g = getGlobal();
     const grad = {};
@@ -121,7 +119,7 @@ export const step = () => {
       });
     });
   });
-  console.timeEnd("Physics step");
+  dev_time_end("Physics step");
   redraw();
 };
 

--- a/src/Scrapbox/add_scrapbox_item.ts
+++ b/src/Scrapbox/add_scrapbox_item.ts
@@ -3,6 +3,7 @@ import { set_status } from "../utils/set_status";
 import { mark_local_changed } from "../utils/mark_local_changed";
 import { updateGlobal } from "../Global/updateGlobal";
 import { get_page_json, make_scrapbox_kozane } from "./make_scrapbox_kozane";
+import { dev_log } from "../utils/dev";
 
 export const add_scrapbox_item = (url: string) => {
   const items = url.split("/");
@@ -44,7 +45,7 @@ export const add_scrapbox_contents = (url: string) => {
     }
   )
     .then((x) => {
-      console.log(x.text);
+      dev_log(x.text);
     })
     .then(() => {
       set_status("done");

--- a/src/Scrapbox/add_scrapbox_links.ts
+++ b/src/Scrapbox/add_scrapbox_links.ts
@@ -17,9 +17,10 @@ import { SCRAPBOX_SIZE } from "./get_scrapbox_bounding_box";
 import { create_kozane } from "../API/add_kozane";
 import { url_to_text } from "../utils/url_to_text";
 import { TWorldCoord } from "../dimension/world_to_screen";
+import { dev_log } from "../utils/dev";
 
 export const add_urls = (urls: string[]) => {
-  console.log(urls);
+  dev_log(urls);
   updateGlobal((g) => {
     g.dialog = "Loading";
     g.statusBar.type = "downloading";
@@ -36,7 +37,7 @@ export const add_urls = (urls: string[]) => {
   const url_to_item = async (url: string) => {
     if (is_scrapbox_url(url)) {
       // scrapbox kozane
-      console.log(url);
+      dev_log(url);
       return get_page_json(url).then((page) =>
         page_to_scrapbox_item(page, url)
       );

--- a/src/dimension/V2.ts
+++ b/src/dimension/V2.ts
@@ -66,6 +66,5 @@ export const normalize = (v: V2): V2 => {
 };
 
 export const equal_v2 = (v1: V2, v2: V2): boolean => {
-  // console.log(v1, v2);
   return v1[0] === v2[0] && v1[1] === v2[1];
 };

--- a/src/dimension/create_squared_group.tsx
+++ b/src/dimension/create_squared_group.tsx
@@ -3,6 +3,7 @@ import { TItem } from "../Global/TItem";
 import { updateGlobal } from "../Global/updateGlobal";
 import { GroupItem } from "../Group/GroupItem";
 import { create_gyazo_item } from "../utils/add_gyazo_item";
+import { dev_log } from "../utils/dev";
 import { url_to_text } from "../utils/url_to_text";
 import { create_squared_position } from "./create_squared_position";
 import { TWorldCoord } from "./world_to_screen";
@@ -62,7 +63,7 @@ export const create_squared_group = (texts: string[]) => {
     kozane_list.push(kozane);
   });
 
-  console.log(kozane_list);
+  dev_log(kozane_list);
   updateGlobal((g) => {
     kozane_list.forEach((kozane) => {
       g.itemStore[kozane.id] = kozane;

--- a/src/dimension/get_group_bounding_box.ts
+++ b/src/dimension/get_group_bounding_box.ts
@@ -82,6 +82,5 @@ export const get_items_bounding_box = (items: TItemId[]): TBoundingBox => {
     }
   });
   const r = { left, right, top, bottom };
-  // console.log("group bounding box", r);
   return r;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import { initGoogleAnalytics } from "./initGoogleAnalytics";
 import addReactNDevTools from "reactn-devtools";
 import { run_user_script } from "./API/run_user_script";
 import { expose_kozaneba_api } from "./API/KozanebaAPI";
+import { dev_log } from "./utils/dev";
 
 const initProduction = () => {
   initSentry();
@@ -36,7 +37,7 @@ expose_kozaneba_api();
 run_user_script();
 
 window.matchMedia("print").addEventListener("change", (e) => {
-  console.log(e);
+  dev_log(e);
   setGlobal({
     print_mode: e.matches,
   });


### PR DESCRIPTION
## Summary
- route runtime `console.log` / `console.time` / `console.timeEnd` calls in app code through the existing `dev_log` / `dev_time` helpers
- remove stale commented-out console debug lines
- keep `console.error` behavior unchanged for actual error reporting

Closes #4

## Verification
- `rg -n "console\\.(log|time|timeEnd)" src --glob "!**/*.test.*" --glob "!src/API/sample/**"` only reports `src/utils/dev.ts` wrappers
- `npm test`
- `npm run build`
- `npm run codex:preflight`
- `npm audit --audit-level=moderate`

Notes: Vite still reports the existing direct `eval` and bundle-size warnings. Those are separate from production console logging.