### PR TITLE
[codex] Add pointer event input handling

### DIFF
--- a/cypress/e2e/kozaneba/test_pointer_events.cy.ts
+++ b/cypress/e2e/kozaneba/test_pointer_events.cy.ts
@@ -1,0 +1,77 @@
+/// <reference types="cypress" />
+
+import { TItemId } from "../../../src/Global/TItemId";
+import { TWorldCoord } from "../../../src/dimension/world_to_screen";
+import { ready_one_kozane } from "../../support/e2e";
+
+const pointer = {
+  pointerId: 1,
+  pointerType: "touch",
+  isPrimary: true,
+  button: 0,
+  buttons: 1,
+  force: true,
+};
+
+const pointerEnd = {
+  ...pointer,
+  buttons: 0,
+};
+
+describe("pointer events", () => {
+  beforeEach(() => {
+    cy.visit("/#blank");
+    cy.viewport(500, 500);
+  });
+
+  it("drags a kozane with pointer events", () => {
+    ready_one_kozane();
+
+    cy.testid("1").trigger("pointerdown", "center", pointer);
+    cy.testid("ba").trigger("pointermove", 240, 240, pointer);
+    cy.testid("ba").trigger("pointerup", 230, 230, pointerEnd);
+
+    cy.getGlobal((g) => g.itemStore["1"].position).should("eql", [-20, -20]);
+  });
+
+  it("selects a kozane with pointer events on the canvas", () => {
+    ready_one_kozane();
+
+    cy.testid("ba").trigger("pointerdown", 100, 100, pointer);
+    cy.testid("ba").trigger("pointermove", 300, 300, pointer);
+    cy.testid("ba").trigger("pointerup", 400, 400, pointerEnd);
+
+    cy.getGlobal((g) => g.selected_items).should("eql", ["1"]);
+  });
+
+  it("drops a kozane into a group from a canvas pointerup", () => {
+    cy.movidea((m) => {
+      m.make_one_kozane({
+        id: "1" as TItemId,
+        text: "1",
+        position: [-100, 0] as TWorldCoord,
+      });
+      m.make_one_kozane({
+        id: "2" as TItemId,
+        text: "2",
+        position: [100, 0] as TWorldCoord,
+      });
+      m.make_items_into_new_group(["2" as TItemId], {
+        id: "G2" as TItemId,
+        text: "G2",
+      });
+    });
+
+    cy.testid("G2").then(($group) => {
+      const rect = $group[0]!.getBoundingClientRect();
+      const dropX = rect.left + rect.width / 2;
+      const dropY = rect.top + rect.height / 2;
+
+      cy.testid("1").trigger("pointerdown", "center", pointer);
+      cy.testid("ba").trigger("pointermove", dropX, dropY, pointer);
+      cy.testid("ba").trigger("pointerup", dropX, dropY, pointerEnd);
+    });
+
+    cy.getGroup("G2", (g) => g.items).should("eql", ["2", "1"]);
+  });
+});

--- a/src/App/App.css
+++ b/src/App/App.css
@@ -3,6 +3,8 @@
   overflow: hidden;
   height: 100%;
   width: 100%;
+  touch-action: none;
+  -webkit-touch-callout: none;
 }
 body {
   height: 100%;

--- a/src/Canvas/Gyazo.tsx
+++ b/src/Canvas/Gyazo.tsx
@@ -53,7 +53,10 @@ export const Gyazo: React.FC<Props> = ({ value, offset }) => {
   ] as TWorldCoord;
   const left_top = position_to_left_top(add_v2w(value.position, o));
 
-  const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+  const onMouseDown = (e: React.MouseEvent<HTMLImageElement>) => {
+    onGenericMouseDown(e, value);
+  };
+  const onPointerDown = (e: React.PointerEvent<HTMLImageElement>) => {
     onGenericMouseDown(e, value);
   };
 
@@ -74,6 +77,7 @@ export const Gyazo: React.FC<Props> = ({ value, offset }) => {
         onLoad={onLoad}
         style={style}
         onMouseDown={onMouseDown}
+        onPointerDown={onPointerDown}
         draggable={false}
       />
       {loaded ? null : <img src="spinner.gif" alt="" />}

--- a/src/Canvas/ItemCanvas.tsx
+++ b/src/Canvas/ItemCanvas.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { useGlobal } from "reactn";
 import { onCanvasMouseDown } from "../Event/onCanvasMouseDown";
 import { onCanvasMouseMove } from "../Event/onCanvasMouseMove";
-import { onCanvasMouseUp } from "../Event/onCanvasMouseUp";
+import { onCanvasMouseUp, onCanvasPointerCancel } from "../Event/onCanvasMouseUp";
 import { onWheel } from "../Event/onWheel";
 import { TItemId } from "../Global/TItemId";
 import { SelectionView } from "../Selection/Selection";
@@ -70,6 +70,10 @@ export const ItemCanvas = React.memo(() => {
       onMouseUp={onCanvasMouseUp}
       onMouseDown={onCanvasMouseDown}
       onMouseMove={onCanvasMouseMove}
+      onPointerUp={onCanvasMouseUp}
+      onPointerDown={onCanvasMouseDown}
+      onPointerMove={onCanvasMouseMove}
+      onPointerCancel={onCanvasPointerCancel}
       data-testid="ba"
       ref={ref}
     >

--- a/src/Event/drop_target.ts
+++ b/src/Event/drop_target.ts
@@ -1,0 +1,54 @@
+import { TItemId } from "../Global/TItemId";
+import { highlight_group, highlight_parent } from "../Group/highlight_group";
+import { get_client_pos } from "./get_client_pos";
+import { TInputEvent } from "./input_event";
+
+const GROUP_ID_PREFIX = "group-";
+let highlighted_group_id: TItemId | null = null;
+
+const group_id_from_element = (element: Element | null): TItemId | null => {
+  const groupElement = element?.closest<HTMLElement>(`[id^="${GROUP_ID_PREFIX}"]`);
+  if (groupElement === undefined || groupElement === null) return null;
+  return groupElement.id.substring(GROUP_ID_PREFIX.length) as TItemId;
+};
+
+const group_id_from_screen_point = ([x, y]: [number, number]): TItemId | null => {
+  const groups = Array.from(
+    document.querySelectorAll<HTMLElement>(`[id^="${GROUP_ID_PREFIX}"]`)
+  );
+  const hitGroups = groups.filter((group) => {
+    const rect = group.getBoundingClientRect();
+    return rect.left <= x && x <= rect.right && rect.top <= y && y <= rect.bottom;
+  });
+  const topmost = hitGroups.at(-1);
+  if (topmost === undefined) return null;
+  return topmost.id.substring(GROUP_ID_PREFIX.length) as TItemId;
+};
+
+export const get_drop_group_id = (
+  event: TInputEvent<Element>
+): TItemId | null => {
+  const [x, y] = get_client_pos(event);
+  const elementGroupId = group_id_from_element(document.elementFromPoint(x, y));
+  if (elementGroupId !== null) return elementGroupId;
+  return group_id_from_screen_point([x, y]);
+};
+
+export const update_drop_group_highlight = (
+  event: TInputEvent<Element>
+) => {
+  const next = get_drop_group_id(event);
+  if (next === highlighted_group_id) return;
+  clear_drop_group_highlight();
+  if (next === null) return;
+  highlight_group(next, true);
+  highlight_parent(next, false);
+  highlighted_group_id = next;
+};
+
+export const clear_drop_group_highlight = () => {
+  if (highlighted_group_id === null) return;
+  highlight_group(highlighted_group_id, false);
+  highlight_parent(highlighted_group_id, true);
+  highlighted_group_id = null;
+};

--- a/src/Event/fast_drag_manager.ts
+++ b/src/Event/fast_drag_manager.ts
@@ -8,15 +8,43 @@ import {
 } from "../dimension/world_to_screen";
 import { dev_log } from "../utils/dev";
 import { get_client_pos } from "./get_client_pos";
+import { TInputEvent } from "./input_event";
 
-let _target: HTMLDivElement | null;
+let _target: HTMLElement | null;
 let _mouse_down_point = [0, 0] as TScreenCoord;
 let _first_element_position = [0, 0] as TScreenCoord;
 let _is_mousemoved = false;
 let _is_dragging = false;
+let _captured_pointer_id: number | null = null;
 
-export const set_target = (event: React.MouseEvent<HTMLDivElement>) => {
+export const capture_pointer_on_canvas = (event: TInputEvent<Element>) => {
+  if (!("pointerId" in event)) return;
+  const canvas = document.getElementById("canvas");
+  if (!(canvas instanceof HTMLDivElement)) return;
+  try {
+    canvas.setPointerCapture(event.pointerId);
+    _captured_pointer_id = event.pointerId;
+  } catch {
+    // The pointer may already be released by the browser, e.g. after cancel.
+  }
+};
+
+export const release_pointer_capture = () => {
+  if (_captured_pointer_id === null) return;
+  const canvas = document.getElementById("canvas");
+  if (canvas instanceof HTMLDivElement) {
+    try {
+      canvas.releasePointerCapture(_captured_pointer_id);
+    } catch {
+      // It is valid for capture to have been lost before explicit release.
+    }
+  }
+  _captured_pointer_id = null;
+};
+
+export const set_target = <T extends HTMLElement>(event: TInputEvent<T>) => {
   dev_log("set_target", event);
+  capture_pointer_on_canvas(event);
   _target = event.currentTarget;
   dev_log("_target", _target);
   _mouse_down_point = get_client_pos(event);
@@ -49,9 +77,10 @@ export const reset_target = () => {
 
   _target = null;
   _is_dragging = false;
+  release_pointer_capture();
 };
 
-export const move_target = (event: React.MouseEvent) => {
+export const move_target = (event: TInputEvent<Element>) => {
   if (_target === null) {
     throw new Error("try to move element:null");
   }
@@ -68,7 +97,7 @@ export const move_target = (event: React.MouseEvent) => {
   _is_mousemoved = true;
 };
 
-export const move_target_on_screen = (event: React.MouseEvent) => {
+export const move_target_on_screen = (event: TInputEvent<Element>) => {
   // for SelectionView, it is not under `world` transform
   if (_target === null) {
     throw new Error("try to move element:null");
@@ -92,7 +121,7 @@ export const is_draggeing = () => {
 };
 
 // currently not used but may useful for refactoring
-export const get_delta = (event: React.MouseEvent<HTMLDivElement>) => {
+export const get_delta = (event: TInputEvent<HTMLElement>) => {
   const delta = sub_v2w(
     screen_to_world(get_client_pos(event)),
     screen_to_world(_mouse_down_point)
@@ -101,7 +130,7 @@ export const get_delta = (event: React.MouseEvent<HTMLDivElement>) => {
 };
 
 // not used
-export const get_target = (): HTMLDivElement => {
+export const get_target = (): HTMLElement => {
   if (_target === null) {
     throw new Error("did get_target but target is null");
   }

--- a/src/Event/finish_selecting.ts
+++ b/src/Event/finish_selecting.ts
@@ -1,17 +1,19 @@
-import React from "react";
 import { convert_bounding_box_screen_to_world } from "../dimension/convert_bounding_box_screen_to_world";
 import { get_item_bounding_box } from "../dimension/get_bounding_box";
 import { isOverlap } from "../dimension/isOverlap";
 import { selection_range_to_bounding_box } from "../dimension/selection_range_to_bounding_box";
 import { TItemId } from "../Global/TItemId";
 import { updateGlobal } from "../Global/updateGlobal";
+import { get_client_pos } from "./get_client_pos";
+import { TInputEvent } from "./input_event";
 
 export function finish_selecting(
-  event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  event: TInputEvent<HTMLDivElement>
 ) {
+  const [x, y] = get_client_pos(event);
   updateGlobal((g) => {
-    g.selectionRange.width = event.pageX - g.selectionRange.left;
-    g.selectionRange.height = event.pageY - g.selectionRange.top;
+    g.selectionRange.width = x - g.selectionRange.left;
+    g.selectionRange.height = y - g.selectionRange.top;
 
     if (g.selectionRange.width === 0 && g.selectionRange.height === 0) {
       // not selected

--- a/src/Event/get_client_pos.ts
+++ b/src/Event/get_client_pos.ts
@@ -1,8 +1,1 @@
-import React from "react";
-import { TScreenCoord } from "../dimension/world_to_screen";
-
-export const get_client_pos = (
-  event: React.MouseEvent | React.DragEvent
-): TScreenCoord => {
-  return [event.clientX, event.clientY] as TScreenCoord;
-};
+export { get_client_pos } from "./input_event";

--- a/src/Event/get_delta.ts
+++ b/src/Event/get_delta.ts
@@ -1,11 +1,11 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { sub_v2w } from "../dimension/V2";
 import { screen_to_world } from "../dimension/world_to_screen";
 import { get_client_pos } from "./get_client_pos";
+import { TInputEvent } from "./input_event";
 
 export const get_delta = (
-  event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  event: TInputEvent<HTMLDivElement>
 ) => {
   const g = getGlobal();
   return sub_v2w(screen_to_world(get_client_pos(event)), g.dragstart_position);

--- a/src/Event/handle_if_is_click.ts
+++ b/src/Event/handle_if_is_click.ts
@@ -1,11 +1,11 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { Sentry } from "../initSentry";
 import { is_dragged } from "./fast_drag_manager";
 import { onGenericClick } from "./onGenericClick";
 import { onSelectionClick } from "./onSelectionClick";
+import { TInputEvent } from "./input_event";
 
-export const handle_if_is_click = (event: React.MouseEvent<HTMLDivElement>) => {
+export const handle_if_is_click = (event: TInputEvent<HTMLDivElement>) => {
   // if the event is click, return true to prevent drag handling
   const g = getGlobal();
   if (!is_dragged()) {

--- a/src/Event/input_event.ts
+++ b/src/Event/input_event.ts
@@ -1,0 +1,43 @@
+import React from "react";
+import { TScreenCoord } from "../dimension/world_to_screen";
+
+export type TInputEvent<T extends Element = HTMLDivElement> =
+  | React.MouseEvent<T>
+  | React.DragEvent<T>
+  | React.PointerEvent<T>
+  | React.TouchEvent<T>;
+
+const COMPAT_MOUSE_EVENT_WINDOW_MS = 700;
+let last_pointer_event_at = 0;
+
+const is_pointer_event = (event: TInputEvent<Element>): event is React.PointerEvent<Element> => {
+  return "pointerId" in event;
+};
+
+export const should_ignore_compat_mouse_event = (
+  event: TInputEvent<Element>
+): boolean => {
+  if (is_pointer_event(event)) {
+    last_pointer_event_at = Date.now();
+    return false;
+  }
+  return Date.now() - last_pointer_event_at < COMPAT_MOUSE_EVENT_WINDOW_MS;
+};
+
+export const get_client_pos = (event: TInputEvent<Element>): TScreenCoord => {
+  if ("changedTouches" in event && event.changedTouches.length > 0) {
+    const touch = event.changedTouches[0]!;
+    return [touch.clientX, touch.clientY] as TScreenCoord;
+  }
+  if ("clientX" in event) {
+    return [event.clientX, event.clientY] as TScreenCoord;
+  }
+  return [0, 0] as TScreenCoord;
+};
+
+export const get_button = (event: TInputEvent<Element>): number => {
+  if ("button" in event) {
+    return event.button;
+  }
+  return 0;
+};

--- a/src/Event/mouseEventMamager.ts
+++ b/src/Event/mouseEventMamager.ts
@@ -1,13 +1,14 @@
-import React from "react";
 import { screen_to_world } from "../dimension/world_to_screen";
 import { updateGlobal } from "../Global/updateGlobal";
 import { dev_log } from "../utils/dev";
 import { set_target } from "./fast_drag_manager";
 import { get_client_pos } from "./get_client_pos";
+import { should_ignore_compat_mouse_event, TInputEvent } from "./input_event";
 
 export const onSelectionMouseDown = (
-  event: React.MouseEvent<HTMLDivElement>
+  event: TInputEvent<HTMLDivElement>
 ) => {
+  if (should_ignore_compat_mouse_event(event)) return;
   dev_log("onSelectionMouseDown");
   set_target(event);
   updateGlobal((g) => {

--- a/src/Event/onCanvasMouseDown.ts
+++ b/src/Event/onCanvasMouseDown.ts
@@ -1,43 +1,49 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { screen_to_world, TScreenCoord } from "../dimension/world_to_screen";
 import { updateGlobal } from "../Global/updateGlobal";
 import { dev_log } from "../utils/dev";
+import { capture_pointer_on_canvas } from "./fast_drag_manager";
+import {
+  get_button,
+  get_client_pos,
+  should_ignore_compat_mouse_event,
+  TInputEvent,
+} from "./input_event";
 import { onCanvasMouseUp } from "./onCanvasMouseUp";
 
 export const onCanvasMouseDown = (
-  event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  event: TInputEvent<HTMLDivElement>
 ) => {
+  if (should_ignore_compat_mouse_event(event)) return;
   dev_log("onCanvasMouseDown");
   if (getGlobal().drag_target !== "") {
     dev_log("previous mouseUp was not handled");
     onCanvasMouseUp(event);
   }
 
-  dev_log("onCanvasMouseDown", event.button);
-  if (event.button === 1 /* middle mouse button */) {
+  capture_pointer_on_canvas(event);
+  const [x, y] = get_client_pos(event);
+  dev_log("onCanvasMouseDown", get_button(event));
+  if (get_button(event) === 1 /* middle mouse button */) {
     updateGlobal((g) => {
       dev_log("middle mouse button");
       if (g.selected_items.length > 0) {
         g.selected_items = [];
       }
-      g.selectionRange.left = event.pageX;
-      g.selectionRange.top = event.pageY;
+      g.selectionRange.left = x;
+      g.selectionRange.top = y;
       g.selectionRange.width = 0;
       g.selectionRange.height = 0;
       g.mouseState = "middle_dragging";
-      g.dragstart_position = screen_to_world([
-        event.pageX,
-        event.pageY,
-      ] as TScreenCoord);
+      g.dragstart_position = screen_to_world([x, y] as TScreenCoord);
     });
   } else {
     updateGlobal((g) => {
       if (g.selected_items.length > 0) {
         g.selected_items = [];
       }
-      g.selectionRange.left = event.pageX;
-      g.selectionRange.top = event.pageY;
+      g.selectionRange.left = x;
+      g.selectionRange.top = y;
       g.selectionRange.width = 0;
       g.selectionRange.height = 0;
       g.mouseState = "selecting";

--- a/src/Event/onCanvasMouseMove.ts
+++ b/src/Event/onCanvasMouseMove.ts
@@ -1,10 +1,11 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { TScreenCoord } from "../dimension/world_to_screen";
 import { updateGlobal } from "../Global/updateGlobal";
 import { dev_log } from "../utils/dev";
+import { clear_drop_group_highlight, update_drop_group_highlight } from "./drop_target";
 import { move_target, move_target_on_screen } from "./fast_drag_manager";
 import { get_client_pos } from "./get_client_pos";
+import { should_ignore_compat_mouse_event, TInputEvent } from "./input_event";
 
 let last_mouse_position = [0, 0] as TScreenCoord;
 export const get_last_mouse_position = () => {
@@ -12,11 +13,13 @@ export const get_last_mouse_position = () => {
 };
 
 export const onCanvasMouseMove = (
-  event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  event: TInputEvent<HTMLDivElement>
 ) => {
+  if (should_ignore_compat_mouse_event(event)) return;
   last_mouse_position = get_client_pos(event);
   const g = getGlobal();
   if (g.mouseState === "selecting") {
+    clear_drop_group_highlight();
     dev_log(`g.mouseState === "selecting"`);
     updateGlobal((g) => {
       g.selectionRange.width = last_mouse_position[0] - g.selectionRange.left;
@@ -25,8 +28,14 @@ export const onCanvasMouseMove = (
   } else if (g.drag_target === "selection") {
     dev_log(`g.drag_target === "selection"`);
     move_target_on_screen(event);
+    update_drop_group_highlight(event);
   } else if (g.drag_target !== "") {
     dev_log(`g.drag_target === ${g.drag_target}`);
     move_target(event);
+    if (g.mouseState !== "middle_dragging" && g.mouseState !== "making_line") {
+      update_drop_group_highlight(event);
+    }
+  } else {
+    clear_drop_group_highlight();
   }
 };

--- a/src/Event/onCanvasMouseUp.ts
+++ b/src/Event/onCanvasMouseUp.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { handle_if_is_click } from "./handle_if_is_click";
 import { get_delta } from "./get_delta";
@@ -8,12 +7,56 @@ import { drag_drop_item } from "./drag_drop_item";
 import { dev_log } from "../utils/dev";
 import { moveCenter } from "../utils/moveCenter";
 import { handle_making_line } from "./handle_making_line";
+import { get_drop_group_id, clear_drop_group_highlight } from "./drop_target";
+import { drag_drop_selection_into_group } from "./drag_drop_selection_into_group";
+import { drag_drop_item_into_group } from "./drag_drop_item_into_group";
+import { move_front } from "../utils/move_front";
+import { updateGlobal } from "../Global/updateGlobal";
+import {
+  release_pointer_capture,
+  reset_target,
+  is_draggeing,
+} from "./fast_drag_manager";
+import {
+  should_ignore_compat_mouse_event,
+  TInputEvent,
+} from "./input_event";
+import { TItemId } from "../Global/TItemId";
+import { find_parent } from "../utils/find_parent";
+
+const is_self_or_descendant_group = (
+  group_id: TItemId,
+  target_id: string
+): boolean => {
+  if (group_id === target_id) return true;
+  let parent = find_parent(group_id);
+  while (parent !== null) {
+    if (parent === target_id) return true;
+    parent = find_parent(parent);
+  }
+  return false;
+};
+
+const get_valid_drop_group_id = (
+  event: TInputEvent<HTMLDivElement>,
+  target_id: string
+) => {
+  const group_id = get_drop_group_id(event);
+  if (group_id === null) return null;
+  if (is_self_or_descendant_group(group_id, target_id)) return null;
+  return group_id;
+};
 
 export const onCanvasMouseUp = (
-  event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  event: TInputEvent<HTMLDivElement>
 ) => {
+  if (should_ignore_compat_mouse_event(event)) return;
   dev_log("onCanvasMouseUp");
-  if (handle_if_is_click(event)) return;
+  clear_drop_group_highlight();
+  if (handle_if_is_click(event)) {
+    release_pointer_capture();
+    return;
+  }
 
   const g = getGlobal();
   const delta = get_delta(event);
@@ -32,11 +75,42 @@ export const onCanvasMouseUp = (
       drag_drop_item(g, delta, g.drag_target);
     }
   } else if (g.drag_target === "selection") {
-    drag_drop_selection(delta);
+    const group_id = get_drop_group_id(event);
+    if (group_id !== null) {
+      move_front(group_id);
+      drag_drop_selection_into_group(group_id, delta);
+    } else {
+      drag_drop_selection(delta);
+    }
   } else if (g.drag_target !== "") {
-    drag_drop_item(g, delta, g.drag_target);
+    const group_id = get_valid_drop_group_id(event, g.drag_target);
+    if (group_id !== null) {
+      move_front(group_id);
+      drag_drop_item_into_group(group_id, delta, g.drag_target);
+    } else {
+      drag_drop_item(g, delta, g.drag_target);
+    }
   } else {
     throw new Error();
   }
+  release_pointer_capture();
   event.preventDefault();
+};
+
+export const onCanvasPointerCancel = (
+  event: TInputEvent<HTMLDivElement>
+) => {
+  if (should_ignore_compat_mouse_event(event)) return;
+  clear_drop_group_highlight();
+  updateGlobal((g) => {
+    g.mouseState = "";
+    g.drag_target = "";
+    g.selectionRange = { top: 0, left: 0, width: 0, height: 0 };
+    g.is_selected = false;
+  });
+  if (is_draggeing()) {
+    reset_target();
+  } else {
+    release_pointer_capture();
+  }
 };

--- a/src/Event/onGenericClick.ts
+++ b/src/Event/onGenericClick.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { TItemId } from "../Global/TItemId";
 import { updateGlobal } from "../Global/updateGlobal";
@@ -7,9 +6,10 @@ import { reset_target } from "./fast_drag_manager";
 import { get_item } from "../utils/get_item";
 import { dev_log } from "../utils/dev";
 import { handle_making_line } from "./handle_making_line";
+import { TInputEvent } from "./input_event";
 
 export const onGenericClick = (
-  event: React.MouseEvent<HTMLDivElement>,
+  event: TInputEvent<HTMLDivElement>,
   id: TItemId
 ) => {
   const g = getGlobal();

--- a/src/Event/onGenericMouseDown.ts
+++ b/src/Event/onGenericMouseDown.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { V2 } from "../dimension/V2";
 import { screen_to_world, TWorldCoord } from "../dimension/world_to_screen";
@@ -9,12 +8,18 @@ import { reset_selection } from "../Selection/reset_selection";
 import { dev_log } from "../utils/dev";
 import { set_target } from "./fast_drag_manager";
 import { get_client_pos } from "./get_client_pos";
+import {
+  get_button,
+  should_ignore_compat_mouse_event,
+  TInputEvent,
+} from "./input_event";
 
-export const onGenericMouseDown = (
-  event: React.MouseEvent<HTMLDivElement>,
+export const onGenericMouseDown = <T extends HTMLElement>(
+  event: TInputEvent<T>,
   value: { id: TItemId; position: V2 }
 ) => {
-  if (event.button === 1 /* middle mouse button */) {
+  if (should_ignore_compat_mouse_event(event)) return;
+  if (get_button(event) === 1 /* middle mouse button */) {
     // ignore
     return;
   }

--- a/src/Event/onGroupMouseDown.ts
+++ b/src/Event/onGroupMouseDown.ts
@@ -1,11 +1,11 @@
-import React from "react";
 import { V2 } from "../dimension/V2";
 import { TItemId } from "../Global/TItemId";
 import { onGenericMouseDown } from "./onGenericMouseDown";
+import { TInputEvent } from "./input_event";
 
 // almost same with onKozaneMouseDown
 export const onGroupMouseDown = (
-  event: React.MouseEvent<HTMLDivElement>,
+  event: TInputEvent<HTMLDivElement>,
   value: { id: TItemId; position: V2 }
 ) => {
   onGenericMouseDown(event, value);

--- a/src/Event/onGroupMouseUp.ts
+++ b/src/Event/onGroupMouseUp.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { getGlobal } from "reactn";
 import { TGroupItem } from "../Global/TGroupItem";
 import { move_front } from "../utils/move_front";
@@ -9,15 +8,23 @@ import { drag_drop_selection_into_group } from "./drag_drop_selection_into_group
 import { drag_drop_item_into_group } from "./drag_drop_item_into_group";
 import { dev_log } from "../utils/dev";
 import { moveCenter } from "../utils/moveCenter";
+import { clear_drop_group_highlight } from "./drop_target";
+import { release_pointer_capture } from "./fast_drag_manager";
+import { should_ignore_compat_mouse_event, TInputEvent } from "./input_event";
 
 export const onGroupMouseUp = (
-  event: React.MouseEvent<HTMLDivElement>,
+  event: TInputEvent<HTMLDivElement>,
   group: TGroupItem
 ) => {
+  if (should_ignore_compat_mouse_event(event)) return;
   dev_log("onGroupMouseUp");
+  clear_drop_group_highlight();
   event.preventDefault();
   event.stopPropagation();
-  if (handle_if_is_click(event)) return;
+  if (handle_if_is_click(event)) {
+    release_pointer_capture();
+    return;
+  }
   const g = getGlobal();
 
   if (g.mouseState === "selecting") {
@@ -44,4 +51,5 @@ export const onGroupMouseUp = (
 
     throw new Error();
   }
+  release_pointer_capture();
 };

--- a/src/Event/onKozaneMouseDown.ts
+++ b/src/Event/onKozaneMouseDown.ts
@@ -1,11 +1,11 @@
-import React from "react";
 import { V2 } from "../dimension/V2";
 import { TItemId } from "../Global/TItemId";
 import { onGenericMouseDown } from "./onGenericMouseDown";
+import { TInputEvent } from "./input_event";
 
 // almost same with onGroupMouseDown
 export const onKozaneMouseDown = (
-  event: React.MouseEvent<HTMLDivElement>,
+  event: TInputEvent<HTMLDivElement>,
   value: { id: TItemId; position: V2 }
 ) => {
   onGenericMouseDown(event, value);

--- a/src/Event/onSelectionClick.ts
+++ b/src/Event/onSelectionClick.ts
@@ -1,9 +1,9 @@
-import React from "react";
 import { updateGlobal } from "../Global/updateGlobal";
 import { show_menu } from "../utils/show_menu";
 import { reset_target } from "./fast_drag_manager";
+import { TInputEvent } from "./input_event";
 
-export const onSelectionClick = (event: React.MouseEvent<HTMLDivElement>) => {
+export const onSelectionClick = (event: TInputEvent<HTMLDivElement>) => {
   show_menu("Selection", event);
   updateGlobal((g) => {
     g.drag_target = "";

--- a/src/Group/Group.tsx
+++ b/src/Group/Group.tsx
@@ -25,7 +25,19 @@ export const Group: React.FC<Props> = React.memo(({ value, offset }) => {
     highlight_parent(value.id, false);
     e.stopPropagation();
   }, [value.id]);
+  const onPointerEnter = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!is_draggeing()) return;
+    highlight_group(value.id, true);
+    highlight_parent(value.id, false);
+    e.stopPropagation();
+  }, [value.id]);
   const onMouseLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (!is_draggeing()) return;
+    highlight_group(value.id, false);
+    highlight_parent(value.id, true);
+    e.stopPropagation();
+  }, [value.id]);
+  const onPointerLeave = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     if (!is_draggeing()) return;
     highlight_group(value.id, false);
     highlight_parent(value.id, true);
@@ -38,21 +50,44 @@ export const Group: React.FC<Props> = React.memo(({ value, offset }) => {
     }
     onGroupMouseUp(e, value);
   }, [value]);
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (self.current !== null) {
+      self.current.style.borderColor = GROUP_BORDER_COLOR;
+    }
+    onGroupMouseUp(e, value);
+  }, [value]);
 
   // let dragging_self = false;
   const onMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     // dragging_self = true;
     onGroupMouseDown(e, value);
   }, [value]);
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    onGroupMouseDown(e, value);
+  }, [value]);
   const common_props = useMemo(() => ({
     key: value.id,
     "data-testid": value.id,
     onMouseDown,
+    onPointerDown,
     onMouseEnter,
+    onPointerEnter,
     onMouseLeave,
+    onPointerLeave,
     onMouseUp,
+    onPointerUp,
     id: "group-" + value.id,
-  }), [value.id, onMouseDown, onMouseEnter, onMouseLeave, onMouseUp]);
+  }), [
+    value.id,
+    onMouseDown,
+    onPointerDown,
+    onMouseEnter,
+    onPointerEnter,
+    onMouseLeave,
+    onPointerLeave,
+    onMouseUp,
+    onPointerUp,
+  ]);
 
   if (value.isOpen === false) {
     const { style, new_offset, text } = calc_closed_style(value, offset);

--- a/src/Kozane/Kozane.tsx
+++ b/src/Kozane/Kozane.tsx
@@ -47,6 +47,9 @@ export const Kozane: React.FC<Props> = React.memo(({
   const onMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     onKozaneMouseDown(e, value);
   }, [value]);
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    onKozaneMouseDown(e, value);
+  }, [value]);
 
   const link_mark = useCallback(() => {
     const url = value.custom?.url;
@@ -79,6 +82,7 @@ export const Kozane: React.FC<Props> = React.memo(({
       key={value.id}
       style={style}
       onMouseDown={onMouseDown}
+      onPointerDown={onPointerDown}
     >
       {link_mark()}
       <KozaneDiv2>{content}</KozaneDiv2>

--- a/src/Scrapbox/Scrapbox.tsx
+++ b/src/Scrapbox/Scrapbox.tsx
@@ -62,6 +62,9 @@ export const Scrapbox: React.FC<Props> = ({ value, offset }) => {
   const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     onGenericMouseDown(e, value);
   };
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    onGenericMouseDown(e, value);
+  };
 
   const b = get_scrapbox_bounding_box(value);
   const left_top = position_to_left_top(
@@ -78,7 +81,11 @@ export const Scrapbox: React.FC<Props> = ({ value, offset }) => {
 
   const lineHeight = 40 * value.scale;
   return (
-    <ScrapboxDiv onMouseDown={onMouseDown} style={style}>
+    <ScrapboxDiv
+      onMouseDown={onMouseDown}
+      onPointerDown={onPointerDown}
+      style={style}
+    >
       <ScrapboxBack />
       <div>
         <div

--- a/src/Selection/Selection.tsx
+++ b/src/Selection/Selection.tsx
@@ -19,6 +19,7 @@ export const SelectionView: React.FC = React.memo(() => {
     <SelectionDiv
       rect={rect}
       onMouseDown={onSelectionMouseDown}
+      onPointerDown={onSelectionMouseDown}
       id="selection-view"
       data-testid="selection-view"
     >

--- a/src/utils/show_menu.tsx
+++ b/src/utils/show_menu.tsx
@@ -2,16 +2,18 @@ import React from "react";
 import styled from "styled-components";
 import { TMenu } from "../Global/TMenu";
 import { updateGlobal } from "../Global/updateGlobal";
+import { get_client_pos, TInputEvent } from "../Event/input_event";
 
-export const show_menu = (menu: TMenu, event: React.MouseEvent) => {
+export const show_menu = (menu: TMenu, event: TInputEvent<Element>) => {
+  const [x, y] = get_client_pos(event);
   updateGlobal((g) => {
     if (g.menu === menu) {
       g.menu = "";
     } else {
       g.menu = menu;
       const a = document.getElementById("menu-anchor") as HTMLDivElement;
-      a.style.left = event.clientX + "px";
-      a.style.top = event.clientY + "px";
+      a.style.left = x + "px";
+      a.style.top = y + "px";
       g.menu_anchor = a;
     }
   });


### PR DESCRIPTION
## Summary

- Normalize mouse / pointer / touch coordinates through a shared input event helper.
- Add PointerEvent handlers and pointer capture to canvas drag/select/drop paths.
- Switch group drop detection away from hover-only behavior by hit-testing the pointerup position.
- Add `touch-action: none` on the canvas and Cypress coverage for touch-like pointer drag, selection, and group drop.

## Why

The iPad investigation found that core Kozaneba canvas interactions were still mouse-event centered. Touch devices do not provide the same hover and mouse sequence guarantees, so drag, selection, and group drop were likely to break or behave inconsistently on iPad Safari.

## Validation

- `npm run build`
- `npm test`
- `npm run codex:preflight`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH CYPRESS_BASE_URL=http://localhost:3001 npm run cypress:kozaneba-all`
  - 18 specs / 34 tests passed with Firebase Auth / Firestore emulators

## Notes

This adds desktop Cypress regression coverage for touch-like pointer events, but it is not a substitute for an iPad Safari real-device smoke test. The remaining acceptance gate is to run the manual iPad checklist for startup, Kozane drag, selection, group drop, line creation, and label editing.
